### PR TITLE
Remove isSelected from RichText render

### DIFF
--- a/src/assets/js/index.jsx
+++ b/src/assets/js/index.jsx
@@ -273,7 +273,6 @@ options.blocks.forEach( ( item ) => {
                                     format="string"
                                     multiline={ control.multiline === 'true' ? 'p' : false }
                                     inlineToolbar={ true }
-                                    isSelected={ true }
                                     onChange={ ( val ) => {
                                         this.onControlChange( val, control, childIndex );
                                     } }


### PR DESCRIPTION
Displaying formatting toolbar is now automatically handled by RichText with changes introduced in [#6419](https://github.com/WordPress/gutenberg/pull/6419). When you omit isSelected and onFocus props, RichText automatically show or hide the control toolbar.