### PR TITLE
Cyrillic block names fix

### DIFF
--- a/src/assets/admin/js/script.js
+++ b/src/assets/admin/js/script.js
@@ -728,7 +728,7 @@ $( document ).on( 'click', '#publish', function( e ) {
         slugVal = slugify( $titleInput.val(), {
             replacement: '-',
             lower: true,
-            remove: /^[0-9-*+~.\$(_)#&\|'"!:;@/\\]/g,
+            remove: /^[0-9-*+~.\$(_)#&\|'"!ь:;@/\\]/g,
         } );
         $slugInput.val( slugVal ).change();
     }


### PR DESCRIPTION
Due the bug in [slugify package](https://github.com/simov/slugify/pull/54) (which imports in main admin script) are impossible to create any lazy-block which contains "ь" character in the name. In addition, cause the script called globally (not only on lazyblock pages) and click event listener added to default wp-publish button, becomes impossible to create any post with `post-title` input.

There is some hotfix until the main bug wasn't fixed.