### PR TITLE
Remove negative margins, adjust tab paddings (WP 5.4)

### DIFF
--- a/src/assets/admin/components/document-tabs/editor.scss
+++ b/src/assets/admin/components/document-tabs/editor.scss
@@ -8,7 +8,6 @@
 
     .lazyblocks-component-document-tabs .components-panel__header.edit-post-sidebar-header {
         display: flex;
-        margin: -16px;
         margin-bottom: -1px;
     }
 }

--- a/src/assets/admin/components/tab-panel/editor.scss
+++ b/src/assets/admin/components/tab-panel/editor.scss
@@ -12,7 +12,7 @@
 
         // single tab
         > .lazyblocks-control-tabs-tab {
-            padding: 15px 20px;
+            padding: 5px 20px;
             margin: 0;
             margin-bottom: -1px;
             color: #555d66;


### PR DESCRIPTION
As noted in Issue #132 (WP 5.4 update distorts paddings in Lazy Block editor). I'm not sure how to target 5.4 or later only though, otherwise this will cause the opposite issue in 5.3 and below.