### PR TITLE
enhance controls with image to contain the image sizes

### DIFF
--- a/src/controls/gallery/script.js
+++ b/src/controls/gallery/script.js
@@ -20,6 +20,7 @@ addFilter( 'lzb.editor.control.gallery.render', 'lzb.editor', ( render, props ) 
                 id: image.id || '',
                 link: image.link || '',
                 url: image.url || '',
+                sizes: image.sizes || '',
             } ) );
 
             props.onChange( result );

--- a/src/controls/image/script.js
+++ b/src/controls/image/script.js
@@ -20,6 +20,7 @@ addFilter( 'lzb.editor.control.image.render', 'lzb.editor', ( render, props ) =>
                 id: val.id || '',
                 link: val.link || '',
                 url: val.url || '',
+                sizes: val.sizes || '',
             } : '';
 
             props.onChange( result );


### PR DESCRIPTION
Enhances controls which have an image (currently image and gallery) to provide the sizes property of the chosen image within the onChange callback and it's result object.

With the sizes information, it's possible to use the js filter to rende a certain image size instead of the full image:

```
wp.hooks.addFilter( 'lzb.editor.control.image.render', 'my.custom.namespace', ( render, controlData, blockData ) => {
	const value = controlData.getValue();

	if (controlData.data.name === 'my_control_1') {
		render.props.value.url = value.sizes.medium.url;
	} else if (controlData.data.name === 'my_control_2') {
		render.props.value.url = value.sizes.medium.url;
	}

	return render;
} );
```

With this extension, it give the flexibility to even use a different image size depending on the component where the control is used.

Closes #162 (Workaround for my issue which is totally fine for me :-))